### PR TITLE
Add Process Killer Scripts

### DIFF
--- a/Helper_Scripts/ros_node_killer.sh
+++ b/Helper_Scripts/ros_node_killer.sh
@@ -1,0 +1,1 @@
+ps aux | grep -E 'op_path_planner|op_local_planner|trajectory_generator|autoware|kinetic|ros' | awk '{print $2}' | xargs kill -9


### PR DESCRIPTION
Added a script to kill remaining processes
after stopping the ROS with CTRL+C

# Pull Request Template

## Description

It ensures that orphan processes left running after ROS is stopped with CTRL+C are terminated.
Additionally, extra processes that need to be terminated can be added to the list, or processes that should not be terminated can be removed from the bash list.


## Link to corresponding Trello card(s)
https://trello.com/c/4fVihoPT


## Type of change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds a functionality)
- [ ] Refactor (improves an existing functionality)


## How Has This Been Tested?

The bash script was tested after the simulation running on PX2 was terminated with CTRL+C.


## Pull request Review Checklist:

#### Git
- [x] Branch name: the name of the branch is descriptive
- [x] Commit history: the history is clean and the commit have descriptive messages
- [x] Authors: the commits have the proper author

#### General Pull Request steps
- [x] Files: all the files modified are needed for the feature/bugfix
- [-] Build: for C++ code, the code builds without error (`catkin_make`)
- [x] Run: the feature runs without error and performs the intended task

#### Code specific steps
- [x] Code conventions: the code follows the project conventions (https://gits-15.sys.kth.se/AD-EYE/AD-EYE_Core/wiki/Conventions)
- [-] Variable names: the variables have descriptive names
- [-] No magic numbers: there is no value in the code that is not assigned to a constant variable
- [-] Doxygen tags: the code has tags for Doxygen as described on https://gits-15.sys.kth.se/AD-EYE/AD-EYE_Core/wiki/Code-Documentation (only for C++ and Python)
- [x] Logic: the code logic performs the intended task and cannot be simplified
